### PR TITLE
Swap Platform preference for title alignment

### DIFF
--- a/src/views/Header.js
+++ b/src/views/Header.js
@@ -365,9 +365,9 @@ const styles = StyleSheet.create({
     right: TITLE_OFFSET,
     top: 0,
     position: 'absolute',
-    alignItems: Platform.OS === 'android'
-      ? 'flex-start'
-      : 'center',
+    alignItems: Platform.OS === 'ios'
+      ? 'center'
+      : 'flex-start',
   },
   left: {
     left: 0,


### PR DESCRIPTION
Centered titles are generally specific to iOS, left alignment of the title appears more common in platforms outside Android and iOS.

This also fits better with the rest of the conditionals that test for iOS instead of Android.
